### PR TITLE
Move to tracking of CPU load average over last minute and memory usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Getting started with multicontainer on resin.io
 
-This example will get you up and running quickly with a multicontainer setup on resin.io. The application creates a plot of your device's CPU temperature at the device's public URL, which is piped over using websockets. The system is composed of a simple static site server, a websocket server, and a proxy. These 3 components are defined in the [docker-compose.yml](docker-compose.yml) as services and are only given as much privilege as is needed.
+This example will get you up and running quickly with a multicontainer setup on resin.io. The application creates a plot of your device's CPU load average and memory usage at the device's public URL, which is piped over using websockets. The system is composed of a simple static site server, a websocket server, and a proxy. These 3 components are defined in the [docker-compose.yml](docker-compose.yml) as services and are only given as much privilege as is needed.
 
-To get this project up and running, you'll need to [sign up](https://dashboard.resin.io/signup) for a resin.io account, create a microservices or starter application, and provision a device (device specific instructions can be found in our [getting started guide](https://docs.resin.io/getting-started). 
+To get this project up and running, you'll need to [sign up](https://dashboard.resin.io/signup) for a resin.io account, create a microservices or starter application, and provision a device (device specific instructions can be found in our [getting started guide](https://docs.resin.io/getting-started).
 
 *Note: Multicontainer functionality requires resinOS v2.12.0 or higher. If you do not see an option to choose a microservices or starter application type, a supported OS version has not yet been released for the selected device type.*
 

--- a/data/Dockerfile.template
+++ b/data/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-alpine-node:8.9.4-slim
+FROM resin/%%RESIN_MACHINE_NAME%%-node:7-slim
 
 # Defines our working directory in container
 WORKDIR /usr/src/app

--- a/frontend/Dockerfile.template
+++ b/frontend/Dockerfile.template
@@ -1,7 +1,14 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-alpine-node:8.9.4-slim
-
+FROM resin/%%RESIN_MACHINE_NAME%%-node:7-slim
 # Defines our working directory in container
 WORKDIR /usr/src/app
+
+RUN apt-get update && \
+    apt-get install -yq wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p static && \
+    wget https://code.jquery.com/jquery-1.12.0.min.js -O static/jquery-1.12.0.min.js && \
+    wget https://code.highcharts.com/highcharts.js -O static/highcharts.js
 
 # Copies the package.json first for better cache on later pushes
 COPY package.json package.json

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html>
   <title>Live Data</title>
-  <script src="https://code.highcharts.com/highcharts.js"></script>
-  <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
+  <script src="highcharts.js"></script>
+  <script src="jquery-1.12.0.min.js"></script>
   <script src="/socket.io/socket.io.js"></script>
 
     <!--
@@ -13,50 +13,76 @@
   $(function () {
     var chart = new Highcharts.Chart({
         chart: {
-            type: 'scatter',
-            margin: [70, 50, 60, 80],
+            zoomType: 'xy',
+            margin: [80, 80, 80, 80],
             renderTo: 'container'
         },
         title: {
-            text: 'CPU Temperature Feed'
+            text: 'CPU Load Average & Memory Usage',
         },
         subtitle: {
-            text: 'Plotting CPU Temperature in real-time using websockets.'
+            text: 'Plotting CPU Load and Memory Info in real-time using websockets.'
         },
         xAxis: {
-            gridLineWidth: 1,
-            minPadding: 0.2,
-            maxPadding: 0.2,
+            gridLineWidth: 5,
             maxZoom: 60
         },
-        yAxis: {
+        yAxis: [{
             title: {
-                text: 'Value'
+                text: 'Memory %age'
             },
-            minPadding: 0.2,
-            maxPadding: 0.2,
-            maxZoom: 60,
+            min: 0,
+            max: 100,
             plotLines: [{
                 value: 0,
                 width: 1,
-                color: '#808080'
-            }]
+                colour: '#808800',
+            }],
+            opposite: true
         },
+        {
+            title: {
+                text: 'LoadAvg'
+            },
+            min: 0,
+            plotLines: [{
+                value: 0,
+                width: 1,
+                colour: '#008888',
+                zIndex: 0
+            }]
+        }],
         plotOptions: {
-            series: {
-                lineWidth: 1,
+            column: {
+                pointPadding: 0,
+                groupPadding: 0
             }
         },
         series: [{
-            data: [[0]]
+            name: 'MemInfo',
+            type: 'column',
+            color: '#008800',
+            grouping: false,
+            yAxis: 0,
+            data: []
+        },
+        {
+            name: 'CpuLoad',
+            type: 'spline',
+            yAxis: 1,
+            data: []
         }]
     });
 
     var socket = io.connect( window.location.protocol + '//' + window.location.hostname);
 
-    socket.on('temperature', function(data) {
-      var series = chart.series[0];
-      series.addPoint([data.t], true, series.data.length > 100);
+    socket.on('loadavg', (data) => {
+        var series = chart.series[1];
+        series.addPoint([data.onemin], true, series.data.length > 100);
+    });
+    socket.on('memory', (data) => {
+        var series = chart.series[0];
+        series.addPoint([data.used], true, series.data.length > 100);
     });
   });
   </script>

--- a/haproxy/Dockerfile.i386-nlp
+++ b/haproxy/Dockerfile.i386-nlp
@@ -1,0 +1,3 @@
+FROM i386/haproxy:1.8.0-alpine
+
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg


### PR DESCRIPTION
This commit also:
* Allows for an `i386-nlp` build (IOT20xx)
* Uses Node 7.x instead of Node 8.x (to allow for `i386-nlp`)
* Moves to a Debian base image instead of Alpine for `data` and `frontend`
  containers (prevents failure to start on some platforms)
* Makes local copies of required scripts for offline use cases