### PR TITLE
add arm64v8 proxy service support

### DIFF
--- a/haproxy/Dockerfile.aarch64
+++ b/haproxy/Dockerfile.aarch64
@@ -1,0 +1,3 @@
+FROM arm64v8/haproxy:1.8.0-alpine
+
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg


### PR DESCRIPTION
Add support for `aarch64` device types like the Nvidia Jetson TX1 & 2