### PR TITLE
retry module loading on failure

### DIFF
--- a/frontend/Dockerfile.template
+++ b/frontend/Dockerfile.template
@@ -6,9 +6,12 @@ RUN apt-get update && \
     apt-get install -yq wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p static && \
-    wget https://code.jquery.com/jquery-1.12.0.min.js -O static/jquery-1.12.0.min.js && \
-    wget https://code.highcharts.com/highcharts.js -O static/highcharts.js
+ENV JQUERY_VERSION=3.3.1
+ENV REQUIREJS_VERSION=2.3.5
+RUN mkdir -p static/js && \
+    wget "https://code.jquery.com/jquery-${JQUERY_VERSION}.min.js" -O static/js/jquery.min.js && \
+    wget https://code.highcharts.com/highcharts.js -O static/js/highcharts.js && \
+    wget "http://requirejs.org/docs/release/${REQUIREJS_VERSION}/minified/require.js" -O static/js/require.js
 
 # Copies the package.json first for better cache on later pushes
 COPY package.json package.json

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -1,91 +1,11 @@
 <!doctype html>
 <html>
-  <title>Live Data</title>
-  <script src="highcharts.js"></script>
-  <script src="jquery-1.12.0.min.js"></script>
-  <script src="/socket.io/socket.io.js"></script>
-
+    <title>Live Data</title>
     <!--
     Highcharts plotting example is based on:
     http://jsfiddle.net/gh/get/jquery/1.9.1/highslide-software/highcharts.com/tree/master/samples/highcharts/demo/dynamic-click-to-add/
     -->
-  <script>
-  $(function () {
-    var chart = new Highcharts.Chart({
-        chart: {
-            zoomType: 'xy',
-            margin: [80, 80, 80, 80],
-            renderTo: 'container'
-        },
-        title: {
-            text: 'CPU Load Average & Memory Usage',
-        },
-        subtitle: {
-            text: 'Plotting CPU Load and Memory Info in real-time using websockets.'
-        },
-        xAxis: {
-            gridLineWidth: 5,
-            maxZoom: 60
-        },
-        yAxis: [{
-            title: {
-                text: 'Memory %age'
-            },
-            min: 0,
-            max: 100,
-            plotLines: [{
-                value: 0,
-                width: 1,
-                colour: '#808800',
-            }],
-            opposite: true
-        },
-        {
-            title: {
-                text: 'LoadAvg'
-            },
-            min: 0,
-            plotLines: [{
-                value: 0,
-                width: 1,
-                colour: '#008888',
-                zIndex: 0
-            }]
-        }],
-        plotOptions: {
-            column: {
-                pointPadding: 0,
-                groupPadding: 0
-            }
-        },
-        series: [{
-            name: 'MemInfo',
-            type: 'column',
-            color: '#008800',
-            grouping: false,
-            yAxis: 0,
-            data: []
-        },
-        {
-            name: 'CpuLoad',
-            type: 'spline',
-            yAxis: 1,
-            data: []
-        }]
-    });
-
-    var socket = io.connect( window.location.protocol + '//' + window.location.hostname);
-
-    socket.on('loadavg', (data) => {
-        var series = chart.series[1];
-        series.addPoint([data.onemin], true, series.data.length > 100);
-    });
-    socket.on('memory', (data) => {
-        var series = chart.series[0];
-        series.addPoint([data.used], true, series.data.length > 100);
-    });
-  });
-  </script>
+  <script data-main="js/app" src="js/require.js"></script>
   <body>
     <div id="container" style="min-width: 310px; height: 400px; max-width: 700px; margin: 0 auto"></div>
   </body>

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -1,0 +1,35 @@
+requirejs.config({
+  paths: {
+    jquery: "jquery.min",
+    highcharts: "highcharts",
+    socketio: "../socket.io/socket.io"
+  },
+  shim: {
+    highcharts: {
+      exports: "Highcharts",
+      deps: ["jquery"]
+    },
+    socketio: {
+      exports: "io"
+    }
+  }
+});
+
+// Retry failed module loading
+function requireWithRetry(modules) {
+  var retryInterval = 5000;
+  var retryCount = 0;
+  var retryOnError = function(err) {
+    var failedId = err.requireModules && err.requireModules[0];
+    // this is what tells RequireJS not to cache the previous failure status
+    requirejs.undef(failedId);
+    retryCount++;
+    console.log(`Retrying module loading #${retryCount} after wait...`);
+    setTimeout(function() {
+      requirejs([failedId], null, retryOnError);
+    }, retryInterval);
+  };
+  requirejs(modules, null, retryOnError);
+}
+// Start our main code
+requireWithRetry(["main"]);

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -1,0 +1,87 @@
+define(["jquery", "highcharts", "socketio"], function($, Highcharts, io) {
+  $(document).ready(function() {
+    var chart = new Highcharts.Chart({
+      chart: {
+        zoomType: "xy",
+        margin: [80, 80, 80, 80],
+        renderTo: "container"
+      },
+      title: {
+        text: "CPU Load Average & Memory Usage"
+      },
+      subtitle: {
+        text: "Plotting CPU Load and Memory Info in real-time using websockets."
+      },
+      xAxis: {
+        gridLineWidth: 5,
+        maxZoom: 60
+      },
+      yAxis: [
+        {
+          title: {
+            text: "Memory %age"
+          },
+          min: 0,
+          max: 100,
+          plotLines: [
+            {
+              value: 0,
+              width: 1,
+              colour: "#808800"
+            }
+          ],
+          opposite: true
+        },
+        {
+          title: {
+            text: "LoadAvg"
+          },
+          min: 0,
+          plotLines: [
+            {
+              value: 0,
+              width: 1,
+              colour: "#008888",
+              zIndex: 0
+            }
+          ]
+        }
+      ],
+      plotOptions: {
+        column: {
+          pointPadding: 0,
+          groupPadding: 0
+        }
+      },
+      series: [
+        {
+          name: "MemInfo",
+          type: "column",
+          color: "#008800",
+          grouping: false,
+          yAxis: 0,
+          data: []
+        },
+        {
+          name: "CpuLoad",
+          type: "spline",
+          yAxis: 1,
+          data: []
+        }
+      ]
+    });
+
+    var socket = io.connect(
+      window.location.protocol + "//" + window.location.hostname
+    );
+
+    socket.on("loadavg", data => {
+      var series = chart.series[1];
+      series.addPoint([data.onemin], true, series.data.length > 100);
+    });
+    socket.on("memory", data => {
+      var series = chart.series[0];
+      series.addPoint([data.used], true, series.data.length > 100);
+    });
+  });
+});


### PR DESCRIPTION
Using `requirejs` for module dependencies, and retry loading any modules that have failed, until they succeed.

This might probably be simplified using `requirejs.onError` instead of making our own `requireWithRetry` function, but probably it is simple enough for the moment.